### PR TITLE
fix: keep text search for non-speech-support browsers

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -2,12 +2,10 @@ import React, { useEffect, useState } from "react";
 import { BsSearch } from "react-icons/bs";
 import { useNavigate } from "react-router-dom";
 import SuggestionBox from "./SuggestionBox";
-import { FaMicrophone } from "react-icons/fa";
 import SpeechRecognition, {
   useSpeechRecognition,
 } from "react-speech-recognition";
-import { RxCross2 } from "react-icons/rx";
-import ListeningModal from "./ListeningModal";
+import SpeechListener from "./SpeechListener";
 
 const Search = () => {
   const navigate = useNavigate();
@@ -64,10 +62,6 @@ const Search = () => {
     // eslint-disable-next-line
   }, [transcript, listening]);
 
-  if (!browserSupportsSpeechRecognition) {
-    return null;
-  }
-
   return (
     <>
       <div className="d-flex justify-between md:w-[55%] w-[63%] relative md:gap-3 gap-1">
@@ -107,20 +101,7 @@ const Search = () => {
           )}
         </form>
 
-        {
-          listening ?
-            <button className="cursor-pointer dark:hover:bg-dark-gray hover:bg-gray-300/40 rounded-full p-2"
-              onClick={SpeechRecognition.stopListening}>
-              <RxCross2 className="text-lg md:text-xl" />
-            </button>
-            :
-            <button className="cursor-pointer dark:hover:bg-dark-gray hover:bg-gray-300/40 rounded-full p-2" onClick={SpeechRecognition.startListening} >
-              <FaMicrophone className="text-lg md:text-xl" />
-            </button>
-        }
-
-
-        {listening && <ListeningModal searchValue={searchValue} stopListening={SpeechRecognition.stopListening} />}
+        {browserSupportsSpeechRecognition && <SpeechListener listening={listening} searchValue={searchValue} />}
       </div>
     </>
   );

--- a/src/components/SpeechListener.jsx
+++ b/src/components/SpeechListener.jsx
@@ -1,0 +1,37 @@
+import { FaMicrophone } from "react-icons/fa";
+import { RxCross2 } from "react-icons/rx";
+import ListeningModal from "./ListeningModal";
+import SpeechRecognition from "react-speech-recognition";
+
+const SpeechListener = (props) => {
+  const { listening, searchValue } = props;
+
+  return (
+    <>
+      {listening ? (
+        <button
+          className="cursor-pointer dark:hover:bg-dark-gray hover:bg-gray-300/40 rounded-full p-2"
+          onClick={SpeechRecognition.stopListening}
+        >
+          <RxCross2 className="text-lg md:text-xl" />
+        </button>
+      ) : (
+        <button
+          className="cursor-pointer dark:hover:bg-dark-gray hover:bg-gray-300/40 rounded-full p-2"
+          onClick={SpeechRecognition.startListening}
+        >
+          <FaMicrophone className="text-lg md:text-xl" />
+        </button>
+      )}
+
+      {listening && (
+        <ListeningModal
+          searchValue={searchValue}
+          stopListening={SpeechRecognition.stopListening}
+        />
+      )}
+    </>
+  );
+};
+
+export default SpeechListener;


### PR DESCRIPTION
Keep the search bar for text search for non-speech support browsers like Firefox